### PR TITLE
Fix AuthClientAcess Naming Issue

### DIFF
--- a/fivetran/resource_connector.go
+++ b/fivetran/resource_connector.go
@@ -1274,13 +1274,13 @@ func resourceConnectorCreateAuthClientAccess(clientAccess []interface{}) *fivetr
 		fivetranAuthClientAccess.ClientID(v)
 	}
 	if v := ca["client_secret"].(string); v != "" {
-		fivetranAuthClientAccess.ClientID(v)
+		fivetranAuthClientAccess.ClientSecret(v)
 	}
 	if v := ca["user_agent"].(string); v != "" {
-		fivetranAuthClientAccess.ClientID(v)
+		fivetranAuthClientAccess.UserAgent(v)
 	}
 	if v := ca["developer_token"].(string); v != "" {
-		fivetranAuthClientAccess.ClientID(v)
+		fivetranAuthClientAccess.DeveloperToken(v)
 	}
 
 	return fivetranAuthClientAccess


### PR DESCRIPTION
- Fix Values for 'user-agent' , 'client_secret' and 'developer_token'